### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: build
 
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/lalgonzales/geo-intro-py/security/code-scanning/1](https://github.com/lalgonzales/geo-intro-py/security/code-scanning/1)

To fix the issue, an explicit `permissions` block should be added to the workflow to define the minimal permissions required for the `GITHUB_TOKEN`. In this case, the workflow appears to only require `contents: read` permissions to fetch and build the content. Adding this block at the root of the workflow will apply the permissions globally to all jobs. If in the future, specific jobs require additional permissions, these can be overridden by defining permissions blocks at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
